### PR TITLE
【#15】利用申請の画面 Issue1 備品に利用中であることを表示する

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -12,7 +12,7 @@ class ItemController extends Controller
 {
     public function show(int $id)
     {
-        $item = Item::where('id', $id)->with('category')->first();
+        $item = Item::where('id', $id)->with('category')->withRentalLogsWithUser()->first();
         $current_user = RentalLog::getCurrentUser($id);
         return view('items.show', compact('item', 'current_user'));
     }

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -24,9 +24,7 @@ class Item extends Model
     public static function latestItems(): Collection
     {
         return self::whereDate('created_at', '>=', Carbon::now()->subDays(self::LATEST_ITEMS_DAYS))
-            ->with('category')->with(['rental_logs'=> function ($query){
-                $query->where('return_date',NULL)->with('user');
-            }])
+            ->with('category')->withRentalLogsWithUser()
             ->get();
     }
 
@@ -43,5 +41,12 @@ class Item extends Model
     public function getLatestRentalLog()
     {
         return $this->rental_logs()->where("return_date", null)->first();
+    }
+
+    public function scopeWithRentalLogsWithUser($query)
+    {
+        $query->with(['rental_logs' => function ($query) {
+            $query->where('return_date', NULL)->with('user');
+        }]);
     }
 }

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -24,7 +24,9 @@ class Item extends Model
     public static function latestItems(): Collection
     {
         return self::whereDate('created_at', '>=', Carbon::now()->subDays(self::LATEST_ITEMS_DAYS))
-            ->with('category')->with('rental_logs.user')
+            ->with('category')->with(['rental_logs'=> function ($query){
+                $query->where('return_date',NULL)->with('user');
+            }])
             ->get();
     }
 

--- a/web/public/css/app.css
+++ b/web/public/css/app.css
@@ -758,6 +758,9 @@ select {
   line-height: 1.75rem;
   font-weight: 700;
 }
+.fixed {
+  position: fixed;
+}
 .absolute {
   position: absolute;
 }
@@ -773,11 +776,14 @@ select {
 .left-2 {
   left: 0.5rem;
 }
-.left-0 {
-  left: 0px;
+.top-0 {
+  top: 0px;
 }
 .right-0 {
   right: 0px;
+}
+.left-0 {
+  left: 0px;
 }
 .z-0 {
   z-index: 0;
@@ -800,6 +806,10 @@ select {
 .my-auto {
   margin-top: auto;
   margin-bottom: auto;
+}
+.mx-10 {
+  margin-left: 2.5rem;
+  margin-right: 2.5rem;
 }
 .mx-2 {
   margin-left: 0.5rem;
@@ -856,23 +866,38 @@ select {
 .ml-12 {
   margin-left: 3rem;
 }
-.mt-1 {
-  margin-top: 0.25rem;
+.ml-1 {
+  margin-left: 0.25rem;
 }
 .mt-2 {
   margin-top: 0.5rem;
 }
-.ml-1 {
-  margin-left: 0.25rem;
+.mr-2 {
+  margin-right: 0.5rem;
+}
+.ml-4 {
+  margin-left: 1rem;
+}
+.-mt-px {
+  margin-top: -1px;
+}
+.mt-1 {
+  margin-top: 0.25rem;
 }
 .-mr-2 {
   margin-right: -0.5rem;
 }
-.mr-2 {
-  margin-right: 0.5rem;
+.mt-5 {
+  margin-top: 1.25rem;
 }
-.mr-1 {
-  margin-right: 0.25rem;
+.mr-3 {
+  margin-right: 0.75rem;
+}
+.ml-auto {
+  margin-left: auto;
+}
+.mt-10 {
+  margin-top: 2.5rem;
 }
 .block {
   display: block;
@@ -916,11 +941,20 @@ select {
 .h-16 {
   height: 4rem;
 }
+.h-8 {
+  height: 2rem;
+}
 .h-20 {
   height: 5rem;
 }
 .h-10 {
   height: 2.5rem;
+}
+.h-7 {
+  height: 1.75rem;
+}
+.min-h-screen {
+  min-height: 100vh;
 }
 .w-5 {
   width: 1.25rem;
@@ -967,11 +1001,35 @@ select {
 .w-6 {
   width: 1.5rem;
 }
+.w-8 {
+  width: 2rem;
+}
 .w-auto {
   width: auto;
 }
+.w-1\/2 {
+  width: 50%;
+}
+.w-screen {
+  width: 100vw;
+}
+.w-\[1280px\] {
+  width: 1280px;
+}
+.max-w-xl {
+  max-width: 36rem;
+}
+.max-w-6xl {
+  max-width: 72rem;
+}
 .max-w-7xl {
   max-width: 80rem;
+}
+.max-w-screen-xl {
+  max-width: 1280px;
+}
+.max-w-screen-2xl {
+  max-width: 1536px;
 }
 .flex-1 {
   flex: 1 1 0%;
@@ -1027,11 +1085,24 @@ select {
      -moz-appearance: none;
           appearance: none;
 }
+.columns-4 {
+  -moz-columns: 4;
+       columns: 4;
+}
 .grid-cols-2 {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
+.grid-cols-1 {
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
 .flex-col {
   flex-direction: column;
+}
+.flex-wrap {
+  flex-wrap: wrap;
 }
 .items-end {
   align-items: flex-end;
@@ -1051,11 +1122,23 @@ select {
 .justify-between {
   justify-content: space-between;
 }
+.justify-items-start {
+  justify-items: start;
+}
 .justify-items-center {
   justify-items: center;
 }
 .gap-8 {
   gap: 2rem;
+}
+.gap-0 {
+  gap: 0px;
+}
+.gap-5 {
+  gap: 1.25rem;
+}
+.gap-y-10 {
+  row-gap: 2.5rem;
 }
 .space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
@@ -1103,11 +1186,14 @@ select {
 .border-t-2 {
   border-top-width: 2px;
 }
-.border-b {
-  border-bottom-width: 1px;
-}
 .border-t {
   border-top-width: 1px;
+}
+.border-r {
+  border-right-width: 1px;
+}
+.border-b {
+  border-bottom-width: 1px;
 }
 .border-gray-300 {
   --tw-border-opacity: 1;
@@ -1132,13 +1218,17 @@ select {
 .border-transparent {
   border-color: transparent;
 }
-.border-gray-100 {
-  --tw-border-opacity: 1;
-  border-color: rgb(243 244 246 / var(--tw-border-opacity));
-}
 .border-gray-200 {
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
+}
+.border-gray-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(156 163 175 / var(--tw-border-opacity));
+}
+.border-gray-100 {
+  --tw-border-opacity: 1;
+  border-color: rgb(243 244 246 / var(--tw-border-opacity));
 }
 .bg-white {
   --tw-bg-opacity: 1;
@@ -1182,6 +1272,9 @@ select {
 }
 .p-2 {
   padding: 0.5rem;
+}
+.p-6 {
+  padding: 1.5rem;
 }
 .px-4 {
   padding-left: 1rem;
@@ -1269,12 +1362,6 @@ select {
 .pb-1 {
   padding-bottom: 0.25rem;
 }
-.pb-4 {
-  padding-bottom: 1rem;
-}
-.pr-2 {
-  padding-right: 0.5rem;
-}
 .text-left {
   text-align: left;
 }
@@ -1303,9 +1390,17 @@ select {
   font-size: 1.875rem;
   line-height: 2.25rem;
 }
+.text-lg {
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
 .text-base {
   font-size: 1rem;
   line-height: 1.5rem;
+}
+.text-xl {
+  font-size: 1.25rem;
+  line-height: 1.75rem;
 }
 .font-medium {
   font-weight: 500;
@@ -1328,11 +1423,14 @@ select {
 .leading-tight {
   line-height: 1.25;
 }
-.leading-4 {
-  line-height: 1rem;
+.leading-7 {
+  line-height: 1.75rem;
 }
 .tracking-wide {
   letter-spacing: 0.025em;
+}
+.tracking-wider {
+  letter-spacing: 0.05em;
 }
 .tracking-widest {
   letter-spacing: 0.1em;
@@ -1381,13 +1479,21 @@ select {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
-.text-indigo-700 {
+.text-gray-200 {
   --tw-text-opacity: 1;
-  color: rgb(67 56 202 / var(--tw-text-opacity));
+  color: rgb(229 231 235 / var(--tw-text-opacity));
+}
+.text-gray-300 {
+  --tw-text-opacity: 1;
+  color: rgb(209 213 219 / var(--tw-text-opacity));
 }
 .text-gray-400 {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
+}
+.text-indigo-700 {
+  --tw-text-opacity: 1;
+  color: rgb(67 56 202 / var(--tw-text-opacity));
 }
 .text-gray-800 {
   --tw-text-opacity: 1;
@@ -1617,6 +1723,14 @@ select {
   opacity: 0.25;
 }
 
+@media (prefers-color-scheme: dark) {
+
+  .dark\:bg-gray-900 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(17 24 39 / var(--tw-bg-opacity));
+  }
+}
+
 @media (min-width: 640px) {
 
   .sm\:-my-px {
@@ -1654,6 +1768,10 @@ select {
 
   .sm\:items-center {
     align-items: center;
+  }
+
+  .sm\:justify-start {
+    justify-content: flex-start;
   }
 
   .sm\:justify-center {
@@ -1695,12 +1813,6 @@ select {
   }
 
   .lg\:px-8 {
-    padding-left: 2rem;
-    padding-right: 2rem;
-  }
-}
-
-.lg\:px-8 {
     padding-left: 2rem;
     padding-right: 2rem;
   }

--- a/web/public/css/app.css
+++ b/web/public/css/app.css
@@ -801,6 +801,10 @@ select {
   margin-top: auto;
   margin-bottom: auto;
 }
+.mx-2 {
+  margin-left: 0.5rem;
+  margin-right: 0.5rem;
+}
 .ml-3 {
   margin-left: 0.75rem;
 }
@@ -846,12 +850,6 @@ select {
 .mb-8 {
   margin-bottom: 2rem;
 }
-.mt-5 {
-  margin-top: 1.25rem;
-}
-.mr-3 {
-  margin-right: 0.75rem;
-}
 .mt-3 {
   margin-top: 0.75rem;
 }
@@ -869,6 +867,12 @@ select {
 }
 .-mr-2 {
   margin-right: -0.5rem;
+}
+.mr-2 {
+  margin-right: 0.5rem;
+}
+.mr-1 {
+  margin-right: 0.25rem;
 }
 .block {
   display: block;
@@ -948,9 +952,6 @@ select {
 .w-4 {
   width: 1rem;
 }
-.w-6 {
-  width: 1.5rem;
-}
 .w-\[1240px\] {
   width: 1240px;
 }
@@ -962,6 +963,9 @@ select {
 }
 .w-7\/12 {
   width: 58.333333%;
+}
+.w-6 {
+  width: 1.5rem;
 }
 .w-auto {
   width: auto;
@@ -1215,6 +1219,10 @@ select {
   padding-left: 1.5rem;
   padding-right: 1.5rem;
 }
+.px-20 {
+  padding-left: 5rem;
+  padding-right: 5rem;
+}
 .py-8 {
   padding-top: 2rem;
   padding-bottom: 2rem;
@@ -1226,10 +1234,6 @@ select {
 .px-1 {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
-}
-.px-20 {
-  padding-left: 5rem;
-  padding-right: 5rem;
 }
 .py-1 {
   padding-top: 0.25rem;
@@ -1264,6 +1268,12 @@ select {
 }
 .pb-1 {
   padding-bottom: 0.25rem;
+}
+.pb-4 {
+  padding-bottom: 1rem;
+}
+.pr-2 {
+  padding-right: 0.5rem;
 }
 .text-left {
   text-align: left;
@@ -1317,6 +1327,9 @@ select {
 }
 .leading-tight {
   line-height: 1.25;
+}
+.leading-4 {
+  line-height: 1rem;
 }
 .tracking-wide {
   letter-spacing: 0.025em;
@@ -1450,128 +1463,160 @@ select {
 .ease-in {
   transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
 }
+
 .hover\:border-gray-300:hover {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
 }
+
 .hover\:bg-gray-100:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
+
 .hover\:bg-gray-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(55 65 81 / var(--tw-bg-opacity));
 }
+
 .hover\:bg-gray-50:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
 }
+
 .hover\:text-gray-500:hover {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
 }
+
 .hover\:text-gray-400:hover {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
 }
+
 .hover\:text-gray-700:hover {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
+
 .hover\:text-gray-900:hover {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
+
 .hover\:text-gray-800:hover {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
 }
+
 .focus\:z-10:focus {
   z-index: 10;
 }
+
 .focus\:border-blue-300:focus {
   --tw-border-opacity: 1;
   border-color: rgb(147 197 253 / var(--tw-border-opacity));
 }
+
 .focus\:border-indigo-300:focus {
   --tw-border-opacity: 1;
   border-color: rgb(165 180 252 / var(--tw-border-opacity));
 }
+
 .focus\:border-indigo-700:focus {
   --tw-border-opacity: 1;
   border-color: rgb(67 56 202 / var(--tw-border-opacity));
 }
+
 .focus\:border-gray-300:focus {
   --tw-border-opacity: 1;
   border-color: rgb(209 213 219 / var(--tw-border-opacity));
 }
+
 .focus\:border-gray-900:focus {
   --tw-border-opacity: 1;
   border-color: rgb(17 24 39 / var(--tw-border-opacity));
 }
+
 .focus\:bg-gray-100:focus {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
+
 .focus\:bg-indigo-100:focus {
   --tw-bg-opacity: 1;
   background-color: rgb(224 231 255 / var(--tw-bg-opacity));
 }
+
 .focus\:bg-gray-50:focus {
   --tw-bg-opacity: 1;
   background-color: rgb(249 250 251 / var(--tw-bg-opacity));
 }
+
 .focus\:text-gray-700:focus {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
+
 .focus\:text-indigo-800:focus {
   --tw-text-opacity: 1;
   color: rgb(55 48 163 / var(--tw-text-opacity));
 }
+
 .focus\:text-gray-800:focus {
   --tw-text-opacity: 1;
   color: rgb(31 41 55 / var(--tw-text-opacity));
 }
+
 .focus\:text-gray-500:focus {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
 }
+
 .focus\:outline-none:focus {
   outline: 2px solid transparent;
   outline-offset: 2px;
 }
+
 .focus\:ring:focus {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
+
 .focus\:ring-indigo-200:focus {
   --tw-ring-opacity: 1;
   --tw-ring-color: rgb(199 210 254 / var(--tw-ring-opacity));
 }
+
 .focus\:ring-opacity-50:focus {
   --tw-ring-opacity: 0.5;
 }
+
 .active\:bg-gray-100:active {
   --tw-bg-opacity: 1;
   background-color: rgb(243 244 246 / var(--tw-bg-opacity));
 }
+
 .active\:bg-gray-900:active {
   --tw-bg-opacity: 1;
   background-color: rgb(17 24 39 / var(--tw-bg-opacity));
 }
+
 .active\:text-gray-700:active {
   --tw-text-opacity: 1;
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
+
 .active\:text-gray-500:active {
   --tw-text-opacity: 1;
   color: rgb(107 114 128 / var(--tw-text-opacity));
 }
+
 .disabled\:opacity-25:disabled {
   opacity: 0.25;
 }
+
 @media (min-width: 640px) {
 
   .sm\:-my-px {
@@ -1633,6 +1678,7 @@ select {
     padding-top: 0px;
   }
 }
+
 @media (min-width: 768px) {
 
   .md\:px-32 {
@@ -1640,6 +1686,7 @@ select {
     padding-right: 8rem;
   }
 }
+
 @media (min-width: 1024px) {
 
   .lg\:px-24 {
@@ -1648,6 +1695,12 @@ select {
   }
 
   .lg\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
+.lg\:px-8 {
     padding-left: 2rem;
     padding-right: 2rem;
   }

--- a/web/resources/views/components/item-card.blade.php
+++ b/web/resources/views/components/item-card.blade.php
@@ -1,7 +1,7 @@
 <section>
     <div class="text-left flex mx-4">
         @if ( $item->rental_logs->first() )
-            <p class="h-4 font-bold mr-1">{{$item->rental_logs->first()->user->name}}さんが利用中</p>
+            <p class="h-4 font-bold">{{$item->rental_logs->first()->user->name}}さんが利用中</p>
             <p class="h-4 font-bold">（〜{{$item->rental_logs->first()->end_date->format('m/d')}}）</p>
         @else
             <p class="h-4"></p>

--- a/web/resources/views/components/item-card.blade.php
+++ b/web/resources/views/components/item-card.blade.php
@@ -1,9 +1,19 @@
-<div class="text-left mx-4" style="width: 300px;">
-    <div class="bg-slate-100">
-        <a href="{{ route('items.show', ['id' => $item->id]) }}">
-            <img class="object-contain h-48 w-96" src="{{ \Storage::url($item->image_path) }}">
-        </a>
+<section>
+    <div class="text-left flex mx-4">
+        @if ( $item->rental_logs->first() )
+            <p class="h-4 font-bold mr-1">{{$item->rental_logs->first()->user->name}}さんが利用中</p>
+            <p class="h-4 font-bold">（〜{{$item->rental_logs->first()->end_date->format('m/d')}}）</p>
+        @else
+            <p class="h-4"></p>
+        @endif
     </div>
-    <p class="font-bold py-2">{{ $item->category->name  ?? '' }}</p>
-    <p>{{ $item->name }}</p>
-</div>
+    <div class="mx-4 mt-2 text-left" style="width: 300px;">
+        <div class="bg-slate-100">
+            <a href="{{ route('items.show', ['id' => $item->id]) }}">
+                <img class="object-contain h-48 w-96" src="{{ \Storage::url($item->image_path) }}">
+            </a>
+        </div>
+        <p class="font-bold py-2">{{ $item->category->name  ?? '' }}</p>
+        <p>{{ $item->name }}</p>
+    </div>
+</section>

--- a/web/resources/views/items/show.blade.php
+++ b/web/resources/views/items/show.blade.php
@@ -2,6 +2,12 @@
 
     <div class="grid grid-cols-2 gap-8 mt-8 px-0 md:px-32">
         <div>
+            <div class="text-left flex mb-2 text-lg">
+                @if ($item->rental_logs->first())
+                    <p class="h-7 font-bold">{{ $item->rental_logs->first()->user->name }}さんが利用中</p>
+                    <p class="h-7 font-bold">（〜{{ $item->rental_logs->first()->end_date->format('m/d') }}）</p>
+                @endif
+            </div>
             <div class="bg-slate-100 text-center">
                 <img class="inline-block object-contain h-96 w-96" src="{{ \Storage::url($item->image_path) }}">
             </div>


### PR DESCRIPTION
## 関連イシュー
- #15 

## 検証したこと
- 貸し出し中の備品については、借りている人の名前, 返却期限が表示されるようにした
  - ダッシュボード
  - 申請画面
  - 備品一覧に関しては #47 で作成するため、検証なし。同一コンポーネントを利用しているためすぐに実装可能。

## エビデンス
### 前提 (rental_logsテーブル。user_id = 1のadminでログイン中)
<img width="1101" alt="スクリーンショット 2022-09-08 15 01 28" src="https://user-images.githubusercontent.com/74942852/189046087-5d7495b2-e1f7-4dcc-8cab-6d5d45da24d8.png">

### ダッシュボード
<img width="1512" alt="スクリーンショット 2022-09-08 15 02 19" src="https://user-images.githubusercontent.com/74942852/189046189-c3c83b10-2af9-4599-ae53-3dabc5a3f4bd.png">

### 申請画面
1. 利用中
<img width="1512" alt="スクリーンショット 2022-09-08 15 02 36" src="https://user-images.githubusercontent.com/74942852/189046221-b1dba992-d6d6-4e6b-945b-1e6b9d263327.png">

2. 未利用
<img width="1512" alt="スクリーンショット 2022-09-08 15 03 07" src="https://user-images.githubusercontent.com/74942852/189046302-a0d21549-e47a-4cfd-b4a5-da58f73f54a2.png">
