### PR TITLE
[#14]自分が利用している備品の詳細画面に申請済みの表示を追加

### DIFF
--- a/web/resources/views/items/show.blade.php
+++ b/web/resources/views/items/show.blade.php
@@ -1,5 +1,7 @@
 <x-app-layout>
-
+    @if ($current_user == Auth::id())
+        <div class="w-screen leading-[65px] text-xl text-center bg-[#D6E6DD] text-[#264F34] font-bold">利用申請済みです</div>
+    @endif
     <div class="grid grid-cols-2 gap-8 mt-8 px-0 md:px-32">
         <div>
             <div class="text-left flex mb-2 text-lg">


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #14 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- 自分が利用している備品の詳細画面では、上に申請済みの表示が出る
- 他の備品の詳細画面では何も表示されない

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
### 前提 (id=1のユーザーでログイン)
rental_logsテーブル
<img width="1096" alt="スクリーンショット 2022-09-08 17 14 43" src="https://user-images.githubusercontent.com/74942852/189071345-5cc632b3-818f-40e8-aa78-f7b46d8fdbfe.png">

### 自分が利用している備品の詳細画面では、上に申請済みの表示が出る
<img width="1512" alt="スクリーンショット 2022-09-08 17 15 10" src="https://user-images.githubusercontent.com/74942852/189071445-27a0f376-8413-4278-bed6-e3d69c3f8089.png">

### 他の備品の詳細画面では何も表示されない
<img width="1512" alt="スクリーンショット 2022-09-08 17 15 33" src="https://user-images.githubusercontent.com/74942852/189071564-1691b86b-6ab8-4345-a2a1-2a557142f360.png">
