### PR TITLE
【#20】ダッシュボード「もうすぐ利用可能 」の表示

### DIFF
--- a/web/app/Http/Controllers/DashboardController.php
+++ b/web/app/Http/Controllers/DashboardController.php
@@ -12,7 +12,6 @@ class DashboardController extends Controller
         $displayLimit = 4;
         $latestItems = Item::latestItems();
         $availableSoonItems = Item::availableSoonItems();
-        dd($availableSoonItems);
         $categoryItems = Category::findCategoriesWithItem();
         return view('dashboard', compact('displayLimit', 'latestItems', 'categoryItems', 'availableSoonItems'));
     }

--- a/web/app/Http/Controllers/DashboardController.php
+++ b/web/app/Http/Controllers/DashboardController.php
@@ -11,7 +11,9 @@ class DashboardController extends Controller
     {
         $displayLimit = 4;
         $latestItems = Item::latestItems();
+        $availableSoonItems = Item::availableSoonItems();
+        // dd($availableSoonItems);
         $categoryItems = Category::findCategoriesWithItem();
-        return view('dashboard', compact('displayLimit', 'latestItems', 'categoryItems'));
+        return view('dashboard', compact('displayLimit', 'latestItems', 'categoryItems', 'availableSoonItems'));
     }
 }

--- a/web/app/Http/Controllers/DashboardController.php
+++ b/web/app/Http/Controllers/DashboardController.php
@@ -12,7 +12,7 @@ class DashboardController extends Controller
         $displayLimit = 4;
         $latestItems = Item::latestItems();
         $availableSoonItems = Item::availableSoonItems();
-        // dd($availableSoonItems);
+        dd($availableSoonItems);
         $categoryItems = Category::findCategoriesWithItem();
         return view('dashboard', compact('displayLimit', 'latestItems', 'categoryItems', 'availableSoonItems'));
     }

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -28,6 +28,16 @@ class Item extends Model
             ->get();
     }
 
+    public static function availableSoonItems(): Collection
+    {
+        $items = self::with('rental_logs')->whereHas('rental_logs', function($q){
+            $q->where('return_date',null);
+        })->get();
+        return $items->filter(function ($item, $key) {
+            return $item::whereDate('end_date', '<=',Carbon::now()->addDays(3));
+            });
+    }
+
     public function category()
     {
         return $this->belongsTo(Category::class);

--- a/web/app/Models/Item.php
+++ b/web/app/Models/Item.php
@@ -30,12 +30,14 @@ class Item extends Model
 
     public static function availableSoonItems(): Collection
     {
-        $items = self::with('rental_logs')->whereHas('rental_logs', function($q){
-            $q->where('return_date',null);
-        })->get();
-        return $items->filter(function ($item, $key) {
-            return $item::whereDate('end_date', '<=',Carbon::now()->addDays(3));
-            });
+        $items = self::with(['rental_logs' => function($query) {
+            $query->where('return_date',null)->whereDate('end_date', '<=',Carbon::now()->addDays(3));
+        }])
+        ->whereHas('rental_logs',function($query) {
+            $query->where('return_date',null)->whereDate('end_date', '<=',Carbon::now()->addDays(3));
+        })
+        ->get();
+        return $items;
     }
 
     public function category()

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -50,6 +50,27 @@
             </div>
         </div>
 
+    <div class="h-full px-8 sm:px-12 lg:px-24">
+        <div class="py-12 text-center">
+            <h2 class="text-2xl font-bold py-6">もうすぐ利用できます</h2>
+            <div class="flex justify-center py-4">
+                @foreach ($availableSoonItems as $key => $item)
+                    @if ($key < $displayLimit)
+                        <x-item-card :item="$item"></x-item-card>
+                    @endif
+                @endforeach
+            </div>
+            <div>
+                <a href="/"
+                    class="inline-block bg-transparent hover:bg-gray-100 text-gray-500 font-semibold py-2 px-6 border border-gray-500 rounded">
+                    <div class="flex items-center">
+                        <span class="px-2">すべて見る</span>
+                        <x-codicon-triangle-down class="inline-block w-5 h-5" />
+                    </div>
+                </a>
+            </div>
+        </div>
+
         @foreach ($categoryItems as $category)
             <div class="py-12 text-center">
                 <h2 class="text-2xl font-bold py-6">{{ $category->name }}</h2>

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -49,7 +49,9 @@
                 </a>
             </div>
         </div>
-
+    @if(count($availableSoonItems) == 0)
+    <p></p>
+    @else
     <div class="h-full px-8 sm:px-12 lg:px-24">
         <div class="py-12 text-center">
             <h2 class="text-2xl font-bold py-6">もうすぐ利用できます</h2>
@@ -70,6 +72,7 @@
                 </a>
             </div>
         </div>
+        @endif
 
         @foreach ($categoryItems as $category)
             <div class="py-12 text-center">


### PR DESCRIPTION
## 関連イシュー
#20 

## 検証したこと
ddで確認（items）
- return_dateがnull（まだ返却されていないもの）
 &&
- end_dateが本日より3日以内
<img width="284" alt="スクリーンショット 2022-09-08 18 48 59" src="https://user-images.githubusercontent.com/74642727/189091719-d23e14e8-e908-4015-beba-be4ec2639338.png">
<img width="317" alt="スクリーンショット 2022-09-08 18 49 20" src="https://user-images.githubusercontent.com/74642727/189091791-451cce07-892a-4bff-8d6c-d10ec2211489.png">
<img width="276" alt="スクリーンショット 2022-09-08 18 50 13" src="https://user-images.githubusercontent.com/74642727/189091988-b7f826dd-ef95-46ff-8fe1-51e727f981b1.png">
<img width="293" alt="スクリーンショット 2022-09-08 18 50 30" src="https://user-images.githubusercontent.com/74642727/189092055-afa4a812-ae1b-4c5b-a2fb-5d5f0f1d9055.png">
<img width="750" alt="スクリーンショット 2022-09-08 18 50 38" src="https://user-images.githubusercontent.com/74642727/189092083-e851486e-ee97-4c2c-9df6-dc7bf293c45e.png">

一致する値がない場合は「もうすぐ利用できます」が表示されない
<img width="716" alt="スクリーンショット 2022-09-08 18 59 32" src="https://user-images.githubusercontent.com/74642727/189094037-467a0847-27f0-426f-9b92-3f028a5aaaf9.png">
<img width="1440" alt="スクリーンショット 2022-09-08 18 59 40" src="https://user-images.githubusercontent.com/74642727/189094073-d6d6d365-570a-4a05-83c3-22e72f359894.png">


## エビデンス
- ダッシュボードに3日以内に返却される備品が表示される
<img width="849" alt="スクリーンショット 2022-09-08 19 15 24" src="https://user-images.githubusercontent.com/74642727/189097349-2c5025d4-65f8-434b-9b07-276b1c42a3c1.png">
<img width="1440" alt="スクリーンショット 2022-09-08 19 15 10" src="https://user-images.githubusercontent.com/74642727/189097304-18b7e81b-f6c5-49e0-9f6f-bf7d0f59f7d9.png">
- 該当する備品がない場合、そのセクションは非表示になる
<img width="729" alt="スクリーンショット 2022-09-08 19 15 54" src="https://user-images.githubusercontent.com/74642727/189097441-00c372db-1efa-41f1-a0cc-a144eddb8d7f.png">
<img width="1440" alt="スクリーンショット 2022-09-08 19 16 06" src="https://user-images.githubusercontent.com/74642727/189097482-a837d0f2-56d1-4b22-8219-6c13269a46cb.png">

