### PR TITLE
【#21】備品詳細へ飛ぶ前にログインモーダルを開く

### DIFF
--- a/web/resources/js/app.js
+++ b/web/resources/js/app.js
@@ -1,7 +1,8 @@
-import './bootstrap';
-import './img_preview';
+import "./bootstrap";
+import "./img_preview";
+import "./open_modal_to_login";
 
-import Alpine from 'alpinejs';
+import Alpine from "alpinejs";
 
 window.Alpine = Alpine;
 

--- a/web/resources/js/open_modal_to_login.js
+++ b/web/resources/js/open_modal_to_login.js
@@ -1,0 +1,15 @@
+const modal = document.getElementById("modal_to_login");
+const buttons = document.getElementsByName("open_modal_button_to_login");
+const closeButton = document.getElementById("close_button");
+const outer = document.getElementById("modal_outer");
+
+if (modal && buttons) {
+    buttons.forEach((button) => {
+        button.addEventListener("click", () => {
+            modal.classList.remove("hidden");
+        });
+    });
+    outer.addEventListener("click", () => {
+        modal.classList.add("hidden");
+    });
+}

--- a/web/resources/views/components/item-card.blade.php
+++ b/web/resources/views/components/item-card.blade.php
@@ -1,19 +1,25 @@
 <section>
     <div class="text-left flex mx-4">
-        @if ( $item->rental_logs->first() )
-            <p class="h-4 font-bold">{{$item->rental_logs->first()->user->name}}さんが利用中</p>
-            <p class="h-4 font-bold">（〜{{$item->rental_logs->first()->end_date->format('m/d')}}）</p>
+        @if ($item->rental_logs->first())
+            <p class="h-4 font-bold">{{ $item->rental_logs->first()->user->name }}さんが利用中</p>
+            <p class="h-4 font-bold">（〜{{ $item->rental_logs->first()->end_date->format('m/d') }}）</p>
         @else
             <p class="h-4"></p>
         @endif
     </div>
     <div class="mx-4 mt-2 text-left" style="width: 300px;">
         <div class="bg-slate-100">
-            <a href="{{ route('items.show', ['id' => $item->id]) }}">
-                <img class="object-contain h-48 w-96" src="{{ \Storage::url($item->image_path) }}">
-            </a>
+            @if (Auth::check())
+                <a href="{{ route('items.show', ['id' => $item->id]) }}">
+                    <img class="object-contain h-48 w-96" src="{{ \Storage::url($item->image_path) }}">
+                </a>
+            @else
+                <button name="open_modal_button_to_login">
+                    <img class="object-contain h-48 w-96" src="{{ \Storage::url($item->image_path) }}">
+                </button>
+            @endif
         </div>
-        <p class="font-bold py-2">{{ $item->category->name  ?? '' }}</p>
+        <p class="font-bold py-2">{{ $item->category->name ?? '' }}</p>
         <p>{{ $item->name }}</p>
     </div>
 </section>

--- a/web/resources/views/components/modal-to-login.blade.php
+++ b/web/resources/views/components/modal-to-login.blade.php
@@ -1,0 +1,11 @@
+<section class="hidden" id="modal_to_login">
+    <div class="w-screen h-screen bg-black opacity-10 fixed top-0 left-0 z-50" id="modal_outer"></div>
+    <section
+        class="w-[600px] h-[400px] bg-[#E5F1F8] fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 rounded-md">
+        <p class="text-[#4EACBA] font-bold text-2xl text-center mt-20">備品詳細を閲覧したい場合は<br />ログインしてください</p>
+        <div class="flex justify-center pt-10">
+            <a href="{{ route('login') }}"
+                class="bg-[#4EACBA] font-bold text-2xl text-white rounded-md shadow-md px-4 py-3 hover:opacity-80">ログイン</a>
+        </div>
+    </section>
+</section>

--- a/web/resources/views/dashboard.blade.php
+++ b/web/resources/views/dashboard.blade.php
@@ -1,4 +1,5 @@
 <x-guest-layout>
+    <x-modal-to-login />
     <div class="bg-hero-pattern bg-cover w-full flex flex-col items-center">
         <h1 class="text-white font-bold text-3xl py-8 mt-4">コミュニティで作る、POSSEのライブラリ</h1>
         <div class="grow py-4 mb-8">


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #21 

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- 未ログイン時、ログイン画面へのリンクを含むモーダルが表示される

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
- モーダル
<img width="1510" alt="スクリーンショット 2022-09-08 20 49 41" src="https://user-images.githubusercontent.com/74942852/189114783-da15ee10-dfd1-47c8-8e6b-c2b83e704e7e.png">
