### PR TITLE
【#13】利用履歴の最新5件を詳細画面に表示

### DIFF
--- a/web/app/Http/Controllers/ItemController.php
+++ b/web/app/Http/Controllers/ItemController.php
@@ -12,7 +12,7 @@ class ItemController extends Controller
 {
     public function show(int $id)
     {
-        $item = Item::where('id', $id)->with('category')->withRentalLogsWithUser()->first();
+        $item = Item::where('id', $id)->with(['category', 'rental_logs.user'])->first();
         $current_user = RentalLog::getCurrentUser($id);
         return view('items.show', compact('item', 'current_user'));
     }

--- a/web/resources/views/items/show.blade.php
+++ b/web/resources/views/items/show.blade.php
@@ -24,6 +24,29 @@
         </div>
         <div>
             <h3 class="PHeading3 border-l-4 p-2 border-blue-500">履歴</h3>
+
+            <table class="table-fixed w-full mt-3">
+                <thead>
+                    <tr>
+                        <th class="px-4 text-left w-20"></th>
+                        <th class="px-4 text-left w-40"></th>
+                        <th class="px-4 text-left w-40"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($item->rental_logs->reverse()->values() as $key => $rental_log)
+                        @if ($key < 5)
+                            <tr class="border-y-2">
+                                <td class="px-4 py-6 font-bold">{{ $rental_log->return_date ? '返却済み' : '' }}</td>
+                                <td class="px-4 py-6">{{ $rental_log->start_date->format('Y-m-d') }} ~
+                                    {{ $rental_log->end_date->format('Y-m-d') }}
+                                </td>
+                                <td class="px-4 py-6">{{ $rental_log->user->name }}</td>
+                            </tr>
+                        @endif
+                    @endforeach
+                </tbody>
+            </table>
         </div>
         <div>
             <h3 class="PHeading3 border-l-4 p-2 border-blue-500">情報</h3>


### PR DESCRIPTION
## 関連イシュー
<!-- このプルリクエストに関連するイシューリンクを記載してください。 -->
- #13

## 検証したこと
<!-- どんなことを検証したのか記載してください？ -->
<!-- 例）〇〇が動くことは確認しました -->
- データベースと画面が一致しており、5件までしか表示されないこと

## エビデンス
<!-- こちらに画面キャプチャを貼ってください -->
- データベース
<img width="1146" alt="スクリーンショット 2022-09-08 21 37 23" src="https://user-images.githubusercontent.com/74942852/189124698-cc642151-0925-463c-b047-d95a3a0c8a52.png">

- 備品詳細画面
<img width="1430" alt="スクリーンショット 2022-09-08 21 37 32" src="https://user-images.githubusercontent.com/74942852/189125031-17a5b789-6107-43d4-b625-3c180a8a1488.png">

